### PR TITLE
Print stylesheets for the documentation pages

### DIFF
--- a/doctrine/layout.html
+++ b/doctrine/layout.html
@@ -261,7 +261,7 @@
   _uacct = "UA-288343-7";
   urchinTracker();
   </script>
-  <a href="http://github.com/doctrine">
-      <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://a248.e.akamai.net/assets.github.com/img/30f550e0d38ceb6ef5b81500c64d970b7fb0f028/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub"></a>
+  <a class="githublink" href="http://github.com/doctrine">
+      <img src="https://a248.e.akamai.net/assets.github.com/img/30f550e0d38ceb6ef5b81500c64d970b7fb0f028/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub"></a>
   </body>
 </html>

--- a/doctrine/static/default.css
+++ b/doctrine/static/default.css
@@ -993,3 +993,44 @@ div.jsactive pre
 #doctrine-projects {
     clear: both;
 }
+.githublink {
+    position: absolute; 
+    top: 0; 
+    right: 0; 
+	display:block;
+}
+.githublink img {
+    border: 0;
+}
+
+
+/**
+ * Some special Print stylesheet for those who want to print documentation pages
+ **/
+@media print {
+  #footer,
+  .footer_popout,
+  #nav.cls,
+  #content .sphinxsidebar,
+  #content .related,
+  .githublink {
+     display:none !important;
+  }
+  #content .bodywrapper {
+      margin:0;
+  }
+  #content .bodywrapper .body {
+      max-width:initial;
+  }
+  #content {
+      font-size:120%;
+  }
+  #content div.body h1,
+  #content div.body h2,
+  #content div.body h3,
+  #content div.body h4,
+  #content div.body h5,
+  #content div.body h6 {
+      background:none;
+  }
+}


### PR DESCRIPTION
I could do more, but I would need to study the html structure of every contexts of the site to adjust.

Only works well for pages within the documentation content.

Blog post: http://renoirboulanger.com/blog/2012/04/feuille-de-style-pour-imprimante-pour-les-pages-de-documentation-de-doctrine2-et-symfony2/
