### PR TITLE
<ol/> styles fixed

### DIFF
--- a/doctrine/static/default.css
+++ b/doctrine/static/default.css
@@ -99,12 +99,17 @@ div.body {
     max-width: 800px;
 }
 
-div.body ul {
+div.body ul,
+div.body ol {
     margin-left: 30px
 }
 
 div.body ul, div.body ul li {
     list-style-type: square;
+}
+
+div.body ol, div.body ol li {
+    list-style-type: decimal;
 }
 
 div.footer {

--- a/doctrine/static/layout.css
+++ b/doctrine/static/layout.css
@@ -48,7 +48,7 @@ a:hover  { color: #00508c; text-decoration:underline; border:0; }
 #content h3 { margin:10px 0 20px 30px; font-weight:bold; font-size:130.0%; }
 #content h4 { margin:10px 0 20px 30px; font-weight:bold; font-size:120.0%; }
 #content h5 { margin:10px 0 20px 30px; font-weight:bold; font-size:110.0%; }
-#content ul li { margin:10px 0 0 30px; }
+#content ul li, #content ol li { margin:10px 0 0 30px; }
 #content ul { margin-bottom: 10px; }
 #content p { margin:0 30px 15px 30px; font-size:93%; line-height:182%; }
 #content dl { margin:0 30px 15px 30px; }


### PR DESCRIPTION
Hello, sorry for my intermediate English. While &lt;ul/&gt; tag has correct default CSS styles &lt;ol/&gt; tag doesn't has it  at all (for example see 'Portability' or 'Supporting Other Databases' sections in DBAL documentations).