### PR TITLE
Finish PR #3 "<ol/> styles fixed" (margin-bottom)

### DIFF
--- a/doctrine/static/layout.css
+++ b/doctrine/static/layout.css
@@ -49,7 +49,7 @@ a:hover  { color: #00508c; text-decoration:underline; border:0; }
 #content h4 { margin:10px 0 20px 30px; font-weight:bold; font-size:120.0%; }
 #content h5 { margin:10px 0 20px 30px; font-weight:bold; font-size:110.0%; }
 #content ul li, #content ol li { margin:10px 0 0 30px; }
-#content ul { margin-bottom: 10px; }
+#content ul, #content ol { margin-bottom: 10px; }
 #content p { margin:0 30px 15px 30px; font-size:93%; line-height:182%; }
 #content dl { margin:0 30px 15px 30px; }
 


### PR DESCRIPTION
Add the missing change noted in https://github.com/doctrine/doctrine-sphinx-theme/pull/3#discussion-diff-57459336.
Before:
![ol-2-b](https://cloud.githubusercontent.com/assets/7404452/14049036/b412d630-f2b2-11e5-8965-34c2c41ecd12.png)
After:
![ol-2-b2](https://cloud.githubusercontent.com/assets/7404452/14048950/0dd3637a-f2b2-11e5-8a8c-c03eca7977a2.png)
(adds missing vertical spacing after the last item (technically, after the list) for `<ol/>` the same as for `<ul/>`).