### PR TITLE
Fix occasional link overlap

### DIFF
--- a/doctrine/static/default.css
+++ b/doctrine/static/default.css
@@ -1001,7 +1001,7 @@ div.jsactive pre
 }
 .githublink {
     position: absolute; 
-    top: 0; 
+    top: -1em; 
     right: 0; 
 	display:block;
 }


### PR DESCRIPTION
This happens with the prev/next/index links in the main navigation.

Adjusting the `top` isn't very elegant, but it does seem to work fine in Firefox.