### PR TITLE
Fix broken ServerGrove image on footer

### DIFF
--- a/doctrine/layout.html
+++ b/doctrine/layout.html
@@ -242,7 +242,7 @@
               {% trans sphinx_version=sphinx_version|e %}Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}
             {%- endif %}
             <br/>
-            <a target="_BLANK" href="http://www.servergrove.com"><img src="http://www.doctrine-project.org/images/servergrove.jpg" /></a>      <br/><br/>
+            <a target="_BLANK" href="http://www.servergrove.com"><img src="http://www.doctrine-project.org/_static/servergrove.jpg" /></a>      <br/><br/>
             <form action="https://www.paypal.com/cgi-bin/webscr" method="post">
               <input type="hidden" name="cmd" value="_s-xclick" />
               <input type="hidden" name="hosted_button_id" value="BAE2E3XANQ77Y" />


### PR DESCRIPTION
- Fix broken image on all docs

Before
---
![captura de pantalla 2017-05-15 a las 12 54 38 p m](https://cloud.githubusercontent.com/assets/5503784/26075312/02c48dbc-3972-11e7-8925-8d805c325412.png)
---

After
---
![captura de pantalla 2017-05-15 a las 12 57 02 p m](https://cloud.githubusercontent.com/assets/5503784/26075323/0b2daf7e-3972-11e7-9a2d-2aee1d2a9b8b.png)
---