### PR TITLE
Fix versions dropdown and allow subprojects there

### DIFF
--- a/doctrine/layout.html
+++ b/doctrine/layout.html
@@ -6,6 +6,8 @@
 {%- set reldelim2 = reldelim2 is not defined and ' |' or reldelim2 %}
 {%- set url_root = pathto('', 1) %}
 {%- if url_root == '#' %}{% set url_root = '' %}{% endif %}
+{%- set versionsHost = 'http://docs.doctrine-project.org' -%}
+{%- if subproject is defined -%}{%- set versionsHost = versionsHost + '/projects/' + subproject -%}{%- endif -%}
 
 {%- macro relbar() %}
     <div class="related">
@@ -47,7 +49,7 @@
 
                 <select name="versions" id="versions">
             {% for slug, url in versions %}
-            <option value="http://readthedocs.org{{ url }}">{{ slug }}</option>
+            <option value="{{ versionsHost }}{{ url }}">{{ slug }}</option>
             {% endfor %}
                 </select>
             {% endif %}


### PR DESCRIPTION
This will fix ORM's version dropdown and also will allow subprojects (every other Doctrine project hosted on readthedocs) to use versions. A subproject must add following line to its `conf.py`:

```
html_context = {'subproject': 'doctrine-mongodb-odm'}
```

Where `doctrine-mongodb-odm` should be the name of the project on readthedocs.